### PR TITLE
Fixing a bug that will allow a value of '0' to bypass validation.

### DIFF
--- a/gravityforms-regex-validation.php
+++ b/gravityforms-regex-validation.php
@@ -82,7 +82,7 @@ class GF_RegEx {
   // validate submitted data against provided regex
   public function validate($result, $value, $form, $field) {
     // if validation has passed so far, and regex validation is enabled, and a pattern was provided, and a value was provided
-    if ($result['is_valid'] && $field['regexValidation'] && !empty($field['regexPattern']) && !empty($value)) {
+    if ($result['is_valid'] && $field['regexValidation'] && !empty($field['regexPattern']) && ( strlen($value) != 0 )) {
       $regex = '/' . $field['regexPattern'] . '/';
       if (preg_match($regex, $value) !== 1) {
         $result['is_valid'] = false;


### PR DESCRIPTION
Hi Matt. 
We use your gravityforms-regex-validation plugin - thanks.
I have found a small bug where a value of 0 will not pass as True for `!empty($value)`, and then regex validation does not happen, allowing '0' to pass strait past the regex - obviously not a desireable outcome.
Please reveiw my simple fix and consider rolling it into your code to fix this issue for all.
Regards...Adam.